### PR TITLE
Add ReadTheDocs Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,7 @@ Introduction
 ============
 
 .. image:: https://readthedocs.org/projects/adafruit-circuitpython-vcnl4010/badge/?version=latest
-
     :target: https://circuitpython.readthedocs.io/projects/vcnl4010/en/latest/
-
     :alt: Documentation Status
 
 .. image :: https://img.shields.io/discord/327254708534116352.svg


### PR DESCRIPTION
Fixed README.rst to display the ReadTheDocs Badge. 
Referenced from https://github.com/adafruit/circuitpython/issues/613